### PR TITLE
Better filename reporting...

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,4 +1,3 @@
-
 var Util = require('util'),
     Style = require('./style'),
     NiceTime = require('./niceTime'),
@@ -95,7 +94,7 @@ var Log = exports = module.exports = function Log() {
 
 Log.from = function(path) {
 
-    var file = path.split('/').pop().split('.')[0];
+    var file = path.split('/').pop().substr(0, input.lastIndexOf('.')) || input;
     var log_function = function() { record(arguments, file); };
     log_function.history = function(){ return history;};
     log_function.array = function(array) { record(array, file);};

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -94,7 +94,8 @@ var Log = exports = module.exports = function Log() {
 
 Log.from = function(path) {
 
-    var file = path.split('/').pop().substr(0, input.lastIndexOf('.')) || input;
+    var file = path.split('/').pop()
+    file = file.substr(0, file.lastIndexOf('.')) || file;
     var log_function = function() { record(arguments, file); };
     log_function.history = function(){ return history;};
     log_function.array = function(array) { record(array, file);};


### PR DESCRIPTION
Thanks for this awesome utility. I had one small problem with it, since we namespace our files with periods. I don't think that is all that uncommon practice. I propose the following modification:

Improve handling of filename so that only the extension is stripped. That is, strip the last segment rather than keeping the first.

Examples:

"this.file.name.js" --> "this.file.name", not "this"
"my.coffee.file.coffee" --> "my.coffee.file", not "my"
